### PR TITLE
[MONOELF] fix: построение запроса с 'IN' и 'NOT IN'

### DIFF
--- a/resource/query/mySQL/DataBaseQueryBuilder.php
+++ b/resource/query/mySQL/DataBaseQueryBuilder.php
@@ -111,9 +111,9 @@ final class DataBaseQueryBuilder implements DataBaseQueryBuilderInterface
 
             $field = $this->escapeField($value['field']);
 
-            if (in_array($value['operator'], ['IN', 'NOT IN'])) {
+            if (in_array($value['operator'], ['IN', 'NOT IN']) === true) {
                 $params = $this->buildParamsForArrayWhere($value['value']);
-                $whereParts[] = "{$field} {$value['operator']} (" . implode(', ', $params) . ")";
+                $whereParts[] = "{$field} {$value['operator']} (" . implode(', ', $params) . ')';
 
                 continue;
             }


### PR DESCRIPTION
Вместо: "field IN (value1)"
строил: "field IN value1"

к примеру "permission IN ADMIN" вместо "permission IN ("ADMIN")"